### PR TITLE
improvement: move "Preview" button to right

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -64,13 +64,6 @@
       >
         <FilesIcon size="20" />
       </button>
-      <button
-        class={activeTab.id === "PREVIEW" ? "tab active" : "tab"}
-        onclick={() => (activeTab.id = "PREVIEW")}
-        title="Preview"
-      >
-        <PlayIcon size="20" />
-      </button>
       {#each Object.entries(openTabs) as [path, tab]}
         <button
           class={activeTab.id === path ? "tab active" : "tab"}
@@ -79,6 +72,13 @@
       {/each}
     </div>
     <div class="panel-right">
+      <button
+        class={activeTab.id === "PREVIEW" ? "tab active" : "tab"}
+        onclick={() => (activeTab.id = "PREVIEW")}
+        title="Preview"
+      >
+        <PlayIcon size="20" />
+      </button>
       <button class="action-btn" onclick={exportWebxdc} title="Share">
         <Share2Icon size="15" />
       </button>
@@ -136,7 +136,6 @@
     height: 100%;
     display: flex;
     margin-right: 5px;
-    align-items: center;
   }
 
   .tab {


### PR DESCRIPTION
- **refactor: rename classes**
- **improvement: move "Preview" button to right**

It makes more sense for "output" actions to be on the right,
separated from "input" (files) tabs.

<img width="496" height="283" alt="image" src="https://github.com/user-attachments/assets/961537a1-b26a-493c-bc84-d1b26b7244c2" />


This also makes the "share" button take full height, incidentally, which I think is good.