### PR TITLE
fix: add `title="Share"` to btn

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -79,7 +79,7 @@
       {/each}
     </div>
     <div class="actions">
-      <button class="action-btn" onclick={exportWebxdc}>
+      <button class="action-btn" onclick={exportWebxdc} title="Share">
         <Share2Icon size="15" />
       </button>
     </div>


### PR DESCRIPTION
This should make it accessible, at least on some screen readers.
